### PR TITLE
Add jumplist before goto function

### DIFF
--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -103,6 +103,7 @@ endfunction
 " s:goto
 "
 function! s:goto(pos) abort
+  normal! m`
   call cursor(a:pos[0], a:pos[1])
   let s:state.matches = s:find_matches(@/, a:pos)
   let l:is_cmdline = mode(1) ==# 'c'


### PR DESCRIPTION
In normal incsearch, jumplist is also updated when you move with n or N.
In searchx, there is a problem that jumplist is not updated when moving, so we changed it so that it is updated.