### PR TITLE
Add SearchxInputChanged autocmd

### DIFF
--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -165,6 +165,8 @@ function! s:on_input() abort
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
       endif
     endif
+
+    doautocmd <nomodeline> User SearchxInputChanged
   catch /.*/
     echomsg string({ 'exception': v:exception, 'throwpoint': v:throwpoint })
   endtry

--- a/doc/searchx.txt
+++ b/doc/searchx.txt
@@ -148,6 +148,10 @@ SearchxCancel~
 
   Cancel searchx prompt.
 
+                                                           *SearchxInputChanged*
+SearchxInputChanged~
+
+  Changed searchx prompt.
 
 
 ==============================================================================


### PR DESCRIPTION
There is no `CmdlineChanged` equivalent among the currently defined events and I would like to use one.
I would like to add `doautocmd` to the end of `in_input`, is it possible?