### PR TITLE
feat: pass `convert` function as a parameter of `searchx#start`

### DIFF
--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -13,6 +13,7 @@ let s:state.firstview = winsaveview()
 let s:state.matches = { 'matches': [], 'current': v:null }
 let s:state.accept_reason = s:AcceptReason.Marker
 let s:state.prompt_emptily = v:true
+let s:state.convert = g:searchx.convert
 
 "
 " searchx#start
@@ -24,6 +25,7 @@ function! searchx#start(...) abort
   let s:state.direction = has_key(l:option, 'dir') ? l:option.dir : s:detect_direction()
   let s:state.firstview = winsaveview()
   let s:state.accept_reason = s:AcceptReason.Return
+  let s:state.convert = get(l:option, 'convert', g:searchx.convert)
   let @/ = ''
   call searchx#searchundo#searchforward(s:state.direction)
   call searchx#searchundo#hlsearch(v:true)
@@ -244,7 +246,7 @@ function! s:on_input(...) abort
       let s:state.prompt_emptily = v:false
     endif
 
-    let l:input = g:searchx.convert(l:input)
+    let l:input = s:state.convert(l:input)
     if @/ ==# l:input
       return
     endif

--- a/doc/searchx.txt
+++ b/doc/searchx.txt
@@ -52,6 +52,9 @@ searchx#start([opts])~
   The `opts` argument can have the following properties.
     - `dir`
       - The search direction. 0 is prev. 1 is next.
+    - `convert`
+      - A function which converts input to search pattern.
+        Default value is |g:searchx.convert|.
 
                                                             *searchx#next_dir()*
 searchx#next_dir()~


### PR DESCRIPTION
- set `convert` to `s:state.convert`
- `s:state.convert` default value is `g:searchx.convert`
- always use `s:state.convert` to convert `input` to search pattern.

I need this, because I want keep mappings in the readme AND add other different mappings like

```vim
" mappings in README
nnoremap ? <Cmd>call searchx#start({ 'dir': 0 })<CR>
nnoremap / <Cmd>call searchx#start({ 'dir': 1 })<CR>
xnoremap ? <Cmd>call searchx#start({ 'dir': 0 })<CR>
xnoremap / <Cmd>call searchx#start({ 'dir': 1 })<CR>

" Other mappings
nnoremap z/ <Cmd>call searchx#start({ 'dir': 1, 'convert': {input -> '\c' .. substitute(input, '\(.\)', '\1.\*', 'g')} })<CR>
xnoremap z/ <Cmd>call searchx#start({ 'dir': 1, 'convert': {input -> '\c' .. substitute(input, '\(.\)', '\1.\*', 'g')} })>CR>
nnoremap z? <Cmd>call searchx#start({ 'dir': 0, 'convert': {input -> '\c' .. substitute(input, '\(.\)', '\1.\*', 'g')} })<CR>
xnoremap z? <Cmd>call searchx#start({ 'dir': 0, 'convert': {input -> '\c' .. substitute(input, '\(.\)', '\1.\*', 'g')} })>CR>

```

