### PR TITLE
feat: repeat/continue latest search which is done by calling `searchx#start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ nnoremap / <Cmd>call searchx#start({ 'dir': 1 })<CR>
 xnoremap ? <Cmd>call searchx#start({ 'dir': 0 })<CR>
 xnoremap / <Cmd>call searchx#start({ 'dir': 1 })<CR>
 cnoremap ; <Cmd>call searchx#select()<CR>
+" repeat/continue latest search which is done by calling function `searchx#start`
+nnoremap <leader>/ <Cmd>call searchx#start({ 'repeat': ['dir', 'convert', 'input', 'save_state_when'] })<CR>
+xnoremap <leader>/ <Cmd>call searchx#start({ 'repeat': ['dir', 'convert', 'input', 'save_state_when'] })<CR>
 
 " Move to next/prev match.
 nnoremap N <Cmd>call searchx#prev_dir()<CR>
@@ -50,6 +53,10 @@ let g:searchx.nohlsearch.jump = v:true
 
 " Marker characters.
 let g:searchx.markers = split('ABCDEFGHIJKLMNOPQRSTUVWXYZ', '.\zs')
+
+" Save state when search result is accepted
+" The state is used to repeat/continue latest search which is done by calling function `searchx#start`
+let g:searchx.save_state_when = 'accepted'
 
 " Convert search pattern.
 function g:searchx.convert(input) abort

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -92,7 +92,7 @@ function! searchx#start(...) abort
         call s:save_state()
       endif
     endif
-    if g:searchx.save_state_when ==? 'accept'
+    if g:searchx.save_state_when ==? 'accepted'
       call s:save_state()
     endif
   endif

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -8,24 +8,40 @@ let s:Direction.Next = 1
 
 let s:state = {}
 let s:state.prompt = v:false
-let s:state.direction = s:Direction.Next
 let s:state.firstview = winsaveview()
 let s:state.matches = { 'matches': [], 'current': v:null }
 let s:state.accept_reason = s:AcceptReason.Marker
 let s:state.prompt_emptily = v:true
+
+let s:state.direction = s:Direction.Next
+let s:state.input = ''
 let s:state.convert = g:searchx.convert
+let s:state.save_state_when = g:searchx.save_state_when
+
+let s:state.latest_direction = s:state.direction
+let s:state.latest_input = s:state.input
+let s:state.latest_convert = s:state.convert
+let s:state.latest_save_state_when = s:state.save_state_when
 
 "
 " searchx#start
 "
 function! searchx#start(...) abort
   let l:option = get(a:000, 0, {})
+  let l:option.dir = get(l:option, 'dir', s:detect_direction())
+  let l:option.input = get(l:option, 'input', '')
+  let l:option.convert = get(l:option, 'convert', g:searchx.convert)
+  let l:option.save_state_when = get(l:option, 'save_state_when', g:searchx.save_state_when)
+  let l:option.repeat = get(l:option, 'repeat', [])
 
   " initialize.
-  let s:state.direction = has_key(l:option, 'dir') ? l:option.dir : s:detect_direction()
+  let s:state.direction = index(l:option.repeat, 'dir') >= 0 ? s:state.latest_direction : l:option.dir
+  let s:state.input = index(l:option.repeat, 'input') >= 0 ? s:state.latest_input : l:option.input
+  let s:state.convert = index(l:option.repeat, 'convert') >= 0 ? s:state.latest_convert : l:option.convert
+  let s:state.save_state_when = index(l:option.repeat, 'save_state_when') >= 0 ? s:state.latest_save_state_when : l:option.save_state_when
+
   let s:state.firstview = winsaveview()
   let s:state.accept_reason = s:AcceptReason.Return
-  let s:state.convert = get(l:option, 'convert', g:searchx.convert)
   let @/ = ''
   call searchx#searchundo#searchforward(s:state.direction)
   call searchx#searchundo#hlsearch(v:true)
@@ -40,6 +56,10 @@ function! searchx#start(...) abort
 
   " Update statusline if enter cmdline mode via `input(...)`.
   call feedkeys("\<Cmd>redrawstatus\<CR>", 'ni')
+
+  if !empty(s:state.input)
+    call feedkeys(s:state.input, 'n')
+  endif
 
   let s:state.prompt = v:true
   let l:return = input(s:state.direction == 1 ? '/' : '?')
@@ -62,11 +82,34 @@ function! searchx#start(...) abort
     if index([s:AcceptReason.Marker], s:state.accept_reason) >= 0
       doautocmd <nomodeline> User SearchxAcceptMarker
       call searchx#searchundo#hlsearch(v:false)
+      if g:searchx.save_state_when ==? 'marker'
+        call s:save_state()
+      endif
     else
       doautocmd <nomodeline> User SearchxAcceptReturn
       call searchx#searchundo#hlsearch(v:true)
+      if g:searchx.save_state_when ==? 'enter'
+        call s:save_state()
+      endif
+    endif
+    if g:searchx.save_state_when ==? 'accept'
+      call s:save_state()
     endif
   endif
+  if g:searchx.save_state_when ==? 'always'
+    call s:save_state()
+  endif
+endfunction
+
+"
+" save_state
+"
+function! s:save_state() abort
+  " save sate for next repeat
+  let s:state.latest_direction = s:state.direction
+  let s:state.latest_input = s:state.input
+  let s:state.latest_convert = s:state.convert
+  let s:state.latest_save_state_when = s:state.save_state_when
 endfunction
 
 "
@@ -224,6 +267,7 @@ function! s:on_input(...) abort
   try
     " Check marker.
     let l:input = getcmdline()
+    let s:state.input = l:input
     if g:searchx.auto_accept && strlen(l:input) > 0
       let l:index = index(g:searchx.markers, l:input[strlen(l:input) - 1])
       if l:index >= 0

--- a/doc/searchx.txt
+++ b/doc/searchx.txt
@@ -23,6 +23,9 @@ Usage                                                            *searchx-usage*
   xnoremap ? <Cmd>call searchx#start({ 'dir': 0 })<CR>
   xnoremap / <Cmd>call searchx#start({ 'dir': 1 })<CR>
   cnoremap ; <Cmd>call searchx#select()<CR>
+  " repeat/continue latest search which is done by calling function `searchx#start`
+  nnoremap <leader>/ <Cmd>call searchx#start({ 'repeat': ['dir', 'convert', 'input', 'save_state_when'] })<CR>
+  xnoremap <leader>/ <Cmd>call searchx#start({ 'repeat': ['dir', 'convert', 'input', 'save_state_when'] })<CR>
 
   " Move to next/prev match.
   nnoremap N <Cmd>call searchx#prev_dir()<CR>
@@ -52,9 +55,28 @@ searchx#start([opts])~
   The `opts` argument can have the following properties.
     - `dir`
       - The search direction. 0 is prev. 1 is next.
+      - If 'dir' in `repeat`, the value of this argument is meaningless.
+    - `input`
+      - The input prefix for searching.
+      - If 'input' in `repeat`, the value of this argument is meaningless.
+      - Default: ''.
     - `convert`
       - A function which converts input to search pattern.
-        Default value is |g:searchx.convert|.
+      - If 'convert' in `repeat`, the value of this argument is meaningless.
+      - Default: |g:searchx.convert|.
+    - `save_state_when`
+      - Save current arguments `dir`, `input`, `convert` and `save_state_when`
+        when `save_state_when` in imminent searching.
+      - If 'save_state_when' in `repeat`, the value of this argument is
+        meaningless.
+      - Available values: 'always', 'accepted', 'marker', 'enter'
+        see |g:searchx.save_state_when|
+      - Default: |g:searchx.save_state_when|.
+    - `repeat`
+      - Repeat `dir`, `input`, `convert` and `save_state_when` which are saved
+        in latest searching.
+      - Available values: 'dir', 'input', 'convert', 'save_state_when'
+      - Default: [].
 
                                                             *searchx#next_dir()*
 searchx#next_dir()~
@@ -116,6 +138,22 @@ g:searchx.convert~
     return a:input[0] .. substitute(a:input[1:], '\\\@<! ', '.\\{-}', 'g')
   endfunction
 <
+
+                                                     *g:searchx.save_state_when*
+g:searchx.save_state_when~
+
+  Save some parameters of |searchx#start()| when |g:searchx.save_state_when|
+  The saved parameters are used to `repeat` latest searching in next call
+  |searchx#start()|
+
+  Availables values: 'always', 'accepted', 'marker', 'enter'
+  'accepted': save arguments when result is 'accepted'
+  'marker': save arguments when result is accepted by 'marker'
+  'enter': save arguments when result is accepted by 'enter'
+  'always': 'always' save searching arugments, not recommended
+
+  Default: 'accepted'
+
                                                            *g:searchx.scrolloff*
 g:searchx.scrolloff~
 

--- a/plugin/searchx.vim
+++ b/plugin/searchx.vim
@@ -10,6 +10,7 @@ let g:searchx.convert = get(g:searchx, 'convert', { input -> input })
 let g:searchx.scrolloff = get(g:searchx, 'scrolloff', v:null)
 let g:searchx.scrolltime = get(g:searchx, 'scrolltime', 0)
 let g:searchx.nohlsearch = get(g:searchx, 'nohlsearch', {'jump': v:false})
+let g:searchx.save_state_when = get(g:searchx, 'save_state_when', 'accept')
 
 augroup searchx-silent
   autocmd User SearchxEnter silent


### PR DESCRIPTION

- save states direction, input, convert and save_state_when when `save_state_when`
- `save_state_when` available values are: 'always', 'accepted', 'marker', 'enter'
- call `searchx#start({ 'repeat': ['dir', 'convert', 'input', 'save_state_when'] })` to repeat
- add the corresponding documentations and examples


I am unfamiliar with `vimscript`, so I don't know whether the new functions will affect the original functions