### PR TITLE
Start labeling results from cursor position instead of top of screen

### DIFF
--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -272,8 +272,8 @@ function! s:on_input(...) abort
 
     " Search off-screen match.
     if empty(s:state.matches.matches)
-      echom "no matches"
-      echom s:state.direction
+      " echom "no matches"
+      " echom s:state.direction
 
       silent noautocmd call winrestview(s:state.firstview)
       let l:next_pos = searchpos(@/, s:state.direction == s:Direction.Next ? 'zn' : 'bn')
@@ -284,8 +284,8 @@ function! s:on_input(...) abort
     " Move to current match.
     else
 
-      echom "matches"
-      echom s:state.direction
+      " echom "matches"
+      " echom s:state.direction
 
       if s:state.matches.current isnot v:null
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
@@ -391,7 +391,7 @@ function! s:find_matches(input, curpos) abort
 
 
     " wrap match
-    
+
     for l:i in range(0, len(l:texts_wrap) - 1)
       let l:text = l:texts_wrap[l:i]
       let l:off = 0
@@ -426,7 +426,7 @@ function! s:find_matches(input, curpos) abort
         let l:off = l:match.end_col
       endwhile
     endfor
-  
+
     " Select current match.
     let l:next = empty(l:next) ? l:prev : l:next
     let l:prev = empty(l:prev) ? l:next : l:prev
@@ -448,7 +448,7 @@ function! s:find_matches(input, curpos) abort
 
 
     " wrap match
-    
+
     for l:i in range(0, len(l:texts_wrap) - 1)
       let l:text = l:texts_wrap[l:i]
       let l:off = 0
@@ -534,7 +534,7 @@ function! s:find_matches(input, curpos) abort
         let l:off = l:match.end_col
       endwhile
     endfor
-  
+
     " " Select current match.
     " let l:next = empty(l:next) ? l:prev : l:next
     " let l:prev = empty(l:prev) ? l:next : l:prev

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -247,6 +247,7 @@ function! s:on_input(...) abort
       else
         let s:state.prompt_emptily = v:true
       endif
+      return
     else
       let s:state.prompt_emptily = v:false
     endif
@@ -272,21 +273,13 @@ function! s:on_input(...) abort
 
     " Search off-screen match.
     if empty(s:state.matches.matches)
-      " echom "no matches"
-      " echom s:state.direction
-
       silent noautocmd call winrestview(s:state.firstview)
       let l:next_pos = searchpos(@/, s:state.direction == s:Direction.Next ? 'zn' : 'bn')
       if l:next_pos[0] == 0
-        " let s:state.direction = s:state.direction == s:Direction.Next ? s:Direction.Prev : s:Direction.Next
       endif
       call searchx#next_dir()
     " Move to current match.
     else
-
-      " echom "matches"
-      " echom s:state.direction
-
       if s:state.matches.current isnot v:null
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
       endif
@@ -341,8 +334,6 @@ function! s:find_matches(input, curpos) abort
   let l:lnum_e = line('w$')
 
   if s:state.direction == 1
-    " echom "cat"
-    " echom "cat2"
     let l:lnum_start = line('w0')
     let l:lnum_s = a:curpos[0]
     let l:lnum_e = line('w$')
@@ -353,7 +344,7 @@ function! s:find_matches(input, curpos) abort
     let l:prev = v:null
     let l:matches = []
 
-    " forward match
+    " forward match from cursor to end of screen in chosen direction
     for l:i in range(0, len(l:texts) - 1)
       let l:text = l:texts[l:i]
       let l:off = 0
@@ -390,8 +381,7 @@ function! s:find_matches(input, curpos) abort
     endfor
 
 
-    " wrap match
-
+    " wrap match, from cursor to end of screen in opposite selected direction
     for l:i in range(0, len(l:texts_wrap) - 1)
       let l:text = l:texts_wrap[l:i]
       let l:off = 0
@@ -435,8 +425,8 @@ function! s:find_matches(input, curpos) abort
       let l:current.current = v:true
     endif
 
+  " reverse direction
   else
-    " echom 'reverse'
 
     let l:next = v:null
     let l:prev = v:null
@@ -446,9 +436,7 @@ function! s:find_matches(input, curpos) abort
     let l:texts_wrap = getbufline('%',l:lnum_start,  a:curpos[0])
     call reverse(l:texts_wrap)
 
-
     " wrap match
-
     for l:i in range(0, len(l:texts_wrap) - 1)
       let l:text = l:texts_wrap[l:i]
       let l:off = 0
@@ -490,7 +478,6 @@ function! s:find_matches(input, curpos) abort
     let l:prev = empty(l:prev) ? l:next : l:prev
 
     let l:current = l:next
-    " let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
     if !empty(l:current)
       let l:current.current = v:true
     endif
@@ -514,37 +501,12 @@ function! s:find_matches(input, curpos) abort
         \   'current': v:false,
         \ }
 
-        " echom len(l:matches)
-        " echom l:matches
-        " echom l:match
-
-"         " nearest next.
-"         if empty(l:next) && (a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col)
-"           let l:next = l:match
-"         endif
-
-"         " nearest prev.
-"         if a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col
-"           let l:prev = l:match
-"         endif
-
         " " add match.
         call add(l:matches, l:match)
 
         let l:off = l:match.end_col
       endwhile
     endfor
-
-    " " Select current match.
-    " let l:next = empty(l:next) ? l:prev : l:next
-    " let l:prev = empty(l:prev) ? l:next : l:prev
-    " " let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
-    " let l:current = l:next
-    " if !empty(l:current)
-    "   let l:current.current = v:true
-    " endif
-
-    " echom l:matches
   endif
 
 

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -243,7 +243,7 @@ function! s:on_input(...) abort
     " Check prompt emptiness
     if strlen(l:input) == 0
       if s:state.prompt_emptily && l:option.is_userinput
-        call feedkeys("\<CR>", 'n')
+        call feedkeys(" \<BS>", 'n')
       else
         let s:state.prompt_emptily = v:true
       endif
@@ -279,11 +279,13 @@ function! s:on_input(...) abort
       endif
       call searchx#next_dir()
     " Move to current match.
+    "
     else
       if s:state.matches.current isnot v:null
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
       endif
       redraw
+
     endif
 
     doautocmd <nomodeline> User SearchxInputChanged
@@ -304,11 +306,13 @@ function s:refresh(...) abort
   for l:match in s:state.matches.matches
     if get(l:option, 'incsearch', v:true)
       if l:match.current
+
         call searchx#highlight#set_incsearch(l:match)
       endif
     endif
 
     if get(l:option, 'marker', v:true)
+
       call searchx#highlight#add_marker(l:match)
     endif
   endfor
@@ -455,7 +459,6 @@ function! s:find_matches(input, curpos) abort
         \   'current': v:false,
         \ }
 
-        echom l:match
         " nearest next.
         if empty(l:next) && (a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col)
           let l:next = l:match

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -333,11 +333,6 @@ function! s:find_matches(input, curpos) abort
   let l:lnum_start = line('w0')
   let l:lnum_s = a:curpos[0]
   let l:lnum_e = line('w$')
-  let l:texts = getbufline('%', l:lnum_s, l:lnum_e)
-
-  let l:texts_wrap = getbufline('%',l:lnum_start,  a:curpos[0] - 1)
-
-  call reverse(l:texts_wrap)
 
   if s:state.direction == 1
     echom "cat"
@@ -441,6 +436,10 @@ function! s:find_matches(input, curpos) abort
     let l:prev = v:null
     let l:matches = []
 
+    let l:texts = getbufline('%', l:lnum_s + 1, l:lnum_e)
+    let l:texts_wrap = getbufline('%',l:lnum_start,  a:curpos[0])
+    call reverse(l:texts_wrap)
+
 
     " wrap match
     
@@ -455,13 +454,14 @@ function! s:find_matches(input, curpos) abort
 
         let l:match = {
         \   'id': len(l:matches) + 1,
-        \   'lnum': l:lnum_s - l:i - 1,
+        \   'lnum': l:lnum_s - l:i,
         \   'col': l:m[1] + 1,
         \   'end_col': l:m[2] + 1,
         \   'marker': get(g:searchx.markers, len(l:matches), v:null),
         \   'current': v:false,
         \ }
 
+        echom l:match
         " nearest next.
         if empty(l:next) && (a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col)
           let l:next = l:match
@@ -482,7 +482,9 @@ function! s:find_matches(input, curpos) abort
     " Select current match.
     let l:next = empty(l:next) ? l:prev : l:next
     let l:prev = empty(l:prev) ? l:next : l:prev
-    let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
+
+    let l:current = l:next
+    " let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
     if !empty(l:current)
       let l:current.current = v:true
     endif
@@ -499,7 +501,7 @@ function! s:find_matches(input, curpos) abort
 
         let l:match = {
         \   'id': len(l:matches) + 1,
-        \   'lnum': l:lnum_s + l:i,
+        \   'lnum': l:lnum_s + l:i + 1,
         \   'col': l:m[1] + 1,
         \   'end_col': l:m[2] + 1,
         \   'marker': get(g:searchx.markers, len(l:matches), v:null),
@@ -527,16 +529,18 @@ function! s:find_matches(input, curpos) abort
       endwhile
     endfor
   
-    " Select current match.
-    let l:next = empty(l:next) ? l:prev : l:next
-    let l:prev = empty(l:prev) ? l:next : l:prev
-    let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
-    if !empty(l:current)
-      let l:current.current = v:true
-    endif
+    " " Select current match.
+    " let l:next = empty(l:next) ? l:prev : l:next
+    " let l:prev = empty(l:prev) ? l:next : l:prev
+    " " let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
+    " let l:current = l:next
+    " if !empty(l:current)
+    "   let l:current.current = v:true
+    " endif
 
     " echom l:matches
   endif
+
 
   return { 'matches': l:matches, 'current': l:current }
 endfunction

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -272,14 +272,20 @@ function! s:on_input(...) abort
 
     " Search off-screen match.
     if empty(s:state.matches.matches)
+      echom "no matches"
+      echom s:state.direction
+
       silent noautocmd call winrestview(s:state.firstview)
       let l:next_pos = searchpos(@/, s:state.direction == s:Direction.Next ? 'zn' : 'bn')
       if l:next_pos[0] == 0
-        let s:state.direction = s:state.direction == s:Direction.Next ? s:Direction.Prev : s:Direction.Next
+        " let s:state.direction = s:state.direction == s:Direction.Next ? s:Direction.Prev : s:Direction.Next
       endif
       call searchx#next_dir()
     " Move to current match.
     else
+
+      echom "matches"
+      echom s:state.direction
 
       if s:state.matches.current isnot v:null
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
@@ -335,8 +341,8 @@ function! s:find_matches(input, curpos) abort
   let l:lnum_e = line('w$')
 
   if s:state.direction == 1
-    echom "cat"
-    echom "cat2"
+    " echom "cat"
+    " echom "cat2"
     let l:lnum_start = line('w0')
     let l:lnum_s = a:curpos[0]
     let l:lnum_e = line('w$')
@@ -430,7 +436,7 @@ function! s:find_matches(input, curpos) abort
     endif
 
   else
-    echom 'reverse'
+    " echom 'reverse'
 
     let l:next = v:null
     let l:prev = v:null

--- a/autoload/searchx.vim
+++ b/autoload/searchx.vim
@@ -36,6 +36,7 @@ function! searchx#start(...) abort
     autocmd!
     autocmd CmdlineChanged * call s:on_input()
   augroup END
+
   doautocmd <nomodeline> User SearchxEnter
 
   " Update statusline if enter cmdline mode via `input(...)`.
@@ -43,12 +44,16 @@ function! searchx#start(...) abort
 
   let s:state.prompt = v:true
   let l:return = input(s:state.direction == 1 ? '/' : '?')
+
   let s:state.prompt = v:false
   let s:state.prompt_emptily = v:true
+
   doautocmd <nomodeline> User SearchxLeave
+
   augroup searchx-run
     autocmd!
   augroup END
+
 
   " finalize.
   call s:clear()
@@ -260,6 +265,7 @@ function! s:on_input(...) abort
     let @/ = l:input
     call searchx#searchundo#searchforward(s:state.direction)
 
+
     " Update view state.
     let s:state.matches = s:find_matches(@/, getcurpos()[1:2])
     call s:refresh({ 'marker': g:searchx.auto_accept })
@@ -274,6 +280,7 @@ function! s:on_input(...) abort
       call searchx#next_dir()
     " Move to current match.
     else
+
       if s:state.matches.current isnot v:null
         call searchx#cursor#goto([s:state.matches.current.lnum, s:state.matches.current.col])
       endif
@@ -322,54 +329,213 @@ endfunction
 " find_matches
 "
 function! s:find_matches(input, curpos) abort
-  let l:lnum_s = line('w0')
+
+  let l:lnum_start = line('w0')
+  let l:lnum_s = a:curpos[0]
   let l:lnum_e = line('w$')
   let l:texts = getbufline('%', l:lnum_s, l:lnum_e)
-  let l:next = v:null
-  let l:prev = v:null
-  let l:matches = []
-  for l:i in range(0, len(l:texts) - 1)
-    let l:text = l:texts[l:i]
 
-    let l:off = 0
-    while l:off < strlen(l:text)
-      let l:m = matchstrpos(l:text, a:input, l:off, 1)
-      if l:m[0] ==# ''
-        break
-      endif
+  let l:texts_wrap = getbufline('%',l:lnum_start,  a:curpos[0] - 1)
 
-      let l:match = {
-      \   'id': len(l:matches) + 1,
-      \   'lnum': l:lnum_s + l:i,
-      \   'col': l:m[1] + 1,
-      \   'end_col': l:m[2] + 1,
-      \   'marker': get(g:searchx.markers, len(l:matches), v:null),
-      \   'current': v:false,
-      \ }
+  call reverse(l:texts_wrap)
 
-      " nearest next.
-      if empty(l:next) && (a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col)
-        let l:next = l:match
-      endif
+  if s:state.direction == 1
+    echom "cat"
+    echom "cat2"
+    let l:lnum_start = line('w0')
+    let l:lnum_s = a:curpos[0]
+    let l:lnum_e = line('w$')
+    let l:texts = getbufline('%', l:lnum_s, l:lnum_e)
+    let l:texts_wrap = getbufline('%',l:lnum_start,  a:curpos[0] - 1)
+    call reverse(l:texts_wrap)
+    let l:next = v:null
+    let l:prev = v:null
+    let l:matches = []
 
-      " nearest prev.
-      if a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col
-        let l:prev = l:match
-      endif
+    " forward match
+    for l:i in range(0, len(l:texts) - 1)
+      let l:text = l:texts[l:i]
+      let l:off = 0
+      while l:off < strlen(l:text)
+        let l:m = matchstrpos(l:text, a:input, l:off, 1)
+        if l:m[0] ==# ''
+          break
+        endif
 
-      " add match.
-      call add(l:matches, l:match)
+        let l:match = {
+        \   'id': len(l:matches) + 1,
+        \   'lnum': l:lnum_s + l:i,
+        \   'col': l:m[1] + 1,
+        \   'end_col': l:m[2] + 1,
+        \   'marker': get(g:searchx.markers, len(l:matches), v:null),
+        \   'current': v:false,
+        \ }
 
-      let l:off = l:match.end_col
-    endwhile
-  endfor
+        " nearest next.
+        if empty(l:next) && (a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col)
+          let l:next = l:match
+        endif
 
-  " Select current match.
-  let l:next = empty(l:next) ? l:prev : l:next
-  let l:prev = empty(l:prev) ? l:next : l:prev
-  let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
-  if !empty(l:current)
-    let l:current.current = v:true
+        " nearest prev.
+        if a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col
+          let l:prev = l:match
+        endif
+
+        " add match.
+        call add(l:matches, l:match)
+
+        let l:off = l:match.end_col
+      endwhile
+    endfor
+
+
+    " wrap match
+    
+    for l:i in range(0, len(l:texts_wrap) - 1)
+      let l:text = l:texts_wrap[l:i]
+      let l:off = 0
+      while l:off < strlen(l:text)
+        let l:m = matchstrpos(l:text, a:input, l:off, 1)
+        if l:m[0] ==# ''
+          break
+        endif
+
+        let l:match = {
+        \   'id': len(l:matches) + 1,
+        \   'lnum': l:lnum_s - l:i - 1,
+        \   'col': l:m[1] + 1,
+        \   'end_col': l:m[2] + 1,
+        \   'marker': get(g:searchx.markers, len(l:matches), v:null),
+        \   'current': v:false,
+        \ }
+
+        " nearest next.
+        if empty(l:next) && (a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col)
+          let l:next = l:match
+        endif
+
+        " nearest prev.
+        if a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col
+          let l:prev = l:match
+        endif
+
+        " add match.
+        call add(l:matches, l:match)
+
+        let l:off = l:match.end_col
+      endwhile
+    endfor
+  
+    " Select current match.
+    let l:next = empty(l:next) ? l:prev : l:next
+    let l:prev = empty(l:prev) ? l:next : l:prev
+    let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
+    if !empty(l:current)
+      let l:current.current = v:true
+    endif
+
+  else
+    echom 'reverse'
+
+    let l:next = v:null
+    let l:prev = v:null
+    let l:matches = []
+
+
+    " wrap match
+    
+    for l:i in range(0, len(l:texts_wrap) - 1)
+      let l:text = l:texts_wrap[l:i]
+      let l:off = 0
+      while l:off < strlen(l:text)
+        let l:m = matchstrpos(l:text, a:input, l:off, 1)
+        if l:m[0] ==# ''
+          break
+        endif
+
+        let l:match = {
+        \   'id': len(l:matches) + 1,
+        \   'lnum': l:lnum_s - l:i - 1,
+        \   'col': l:m[1] + 1,
+        \   'end_col': l:m[2] + 1,
+        \   'marker': get(g:searchx.markers, len(l:matches), v:null),
+        \   'current': v:false,
+        \ }
+
+        " nearest next.
+        if empty(l:next) && (a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col)
+          let l:next = l:match
+        endif
+
+        " nearest prev.
+        if a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col
+          let l:prev = l:match
+        endif
+
+        " add match.
+        call add(l:matches, l:match)
+
+        let l:off = l:match.end_col
+      endwhile
+    endfor
+
+    " Select current match.
+    let l:next = empty(l:next) ? l:prev : l:next
+    let l:prev = empty(l:prev) ? l:next : l:prev
+    let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
+    if !empty(l:current)
+      let l:current.current = v:true
+    endif
+
+    " forward match
+    for l:i in range(0, len(l:texts) - 1)
+      let l:text = l:texts[l:i]
+      let l:off = 0
+      while l:off < strlen(l:text)
+        let l:m = matchstrpos(l:text, a:input, l:off, 1)
+        if l:m[0] ==# ''
+          break
+        endif
+
+        let l:match = {
+        \   'id': len(l:matches) + 1,
+        \   'lnum': l:lnum_s + l:i,
+        \   'col': l:m[1] + 1,
+        \   'end_col': l:m[2] + 1,
+        \   'marker': get(g:searchx.markers, len(l:matches), v:null),
+        \   'current': v:false,
+        \ }
+
+        " echom len(l:matches)
+        " echom l:matches
+        " echom l:match
+
+"         " nearest next.
+"         if empty(l:next) && (a:curpos[0] < l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] <= l:match.col)
+"           let l:next = l:match
+"         endif
+
+"         " nearest prev.
+"         if a:curpos[0] > l:match.lnum || a:curpos[0] == l:match.lnum && a:curpos[1] >= l:match.col
+"           let l:prev = l:match
+"         endif
+
+        " " add match.
+        call add(l:matches, l:match)
+
+        let l:off = l:match.end_col
+      endwhile
+    endfor
+  
+    " Select current match.
+    let l:next = empty(l:next) ? l:prev : l:next
+    let l:prev = empty(l:prev) ? l:next : l:prev
+    let l:current = s:state.direction == s:Direction.Next ? l:next : l:prev
+    if !empty(l:current)
+      let l:current.current = v:true
+    endif
+
+    " echom l:matches
   endif
 
   return { 'matches': l:matches, 'current': l:current }


### PR DESCRIPTION
Hi! So this is not an actual final pull request - but I just wanted to know if this sort of functionality would be okay with you as a future pull request. The code is very messy but I wanted to know if you would consider this feature at all. Basically instead of having the results be labeled from the top of the screen regardless of the cursor position this will start labelling results from the cursor position. Do you have any ideas on a better way to write this functionality? Basically I have to call the search function twice. I'm also not very familiar with vimscript. 

I've been using this functionality for a while now and it seems to work well overall. I prefer this search method better than leap or any other of the jumping methods! It's nice to have search and jumping combined imo.

Anyways would love to hear your feedback. Thanks!